### PR TITLE
Fix typo in hippocampus demo

### DIFF
--- a/Demo_hypothesis_testing.ipynb
+++ b/Demo_hypothesis_testing.ipynb
@@ -723,9 +723,9 @@
     "ax1=cebra.plot_embedding(ax=ax1, embedding=cebra_pos, embedding_labels=\"grey\", title='position only')\n",
     "ax2=cebra.plot_embedding(ax=ax2, embedding=cebra_dir, embedding_labels=\"grey\", title='direction only')\n",
     "ax3=cebra.plot_embedding(ax=ax3, embedding=cebra_posdir, embedding_labels=\"grey\", title='position+direction')\n",
-    "ax4=cebra.plot_embedding(ax=ax4, embedding=cebra_pos_shuffled, embedding_labels=\"grey\", title='position, shuffled')\n",
-    "ax5=cebra.plot_embedding(ax=ax5, embedding=cebra_dir_shuffled, embedding_labels=\"grey\", title='direction, shuffled')\n",
-    "ax6=cebra.plot_embedding(ax=ax6, embedding=cebra_posdir_shuffled, embedding_labels=\"grey\", title='pos+dir, shuffled')\n",
+    "ax4=cebra.plot_embedding(ax=ax4, embedding=cebra_pos_shuffled_train, embedding_labels=\"grey\", title='position, shuffled')\n",
+    "ax5=cebra.plot_embedding(ax=ax5, embedding=cebra_dir_shuffled_train, embedding_labels=\"grey\", title='direction, shuffled')\n",
+    "ax6=cebra.plot_embedding(ax=ax6, embedding=cebra_posdir_shuffled_train, embedding_labels=\"grey\", title='pos+dir, shuffled')\n",
     "    \n",
     "plt.show()"
    ]


### PR DESCRIPTION
The hippocampus demo had a typo in the naming for the shuffled embeddings, which causes the last plot to break.