### PR TITLE
Add --pre to all notebooks

### DIFF
--- a/Demo_Allen.ipynb
+++ b/Demo_Allen.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {
@@ -858,7 +858,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.8.0"
   },
   "vscode": {
    "interpreter": {

--- a/Demo_cohomology.ipynb
+++ b/Demo_cohomology.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_consistency.ipynb
+++ b/Demo_consistency.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_conv-pivae.ipynb
+++ b/Demo_conv-pivae.ipynb
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_decoding.ipynb
+++ b/Demo_decoding.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_hippocampus.ipynb
+++ b/Demo_hippocampus.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[dev,demos]'"
+    "!pip install --pre 'cebra[dev,demos]'"
    ]
   },
   {

--- a/Demo_hippocampus_multisession.ipynb
+++ b/Demo_hippocampus_multisession.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {
@@ -482,7 +482,7 @@
   "kernelspec": {
    "display_name": "cebra",
    "language": "python",
-   "name": "cebra"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -495,11 +495,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.0"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "dc327929684d2c13e929b2699e1b37518dbb61b921da51c352c926069002ee0e"
-   }
   }
  },
  "nbformat": 4,

--- a/Demo_hypothesis_testing.ipynb
+++ b/Demo_hypothesis_testing.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_learnable_temperature.ipynb
+++ b/Demo_learnable_temperature.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_primate_reaching.ipynb
+++ b/Demo_primate_reaching.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[dev,demos]'"
+    "!pip install --pre 'cebra[dev,demos]'"
    ]
   },
   {

--- a/Demo_primate_reaching_mse_loss.ipynb
+++ b/Demo_primate_reaching_mse_loss.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {

--- a/Demo_synthetic_exp.ipynb
+++ b/Demo_synthetic_exp.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install 'cebra[datasets,demos]'"
+    "!pip install --pre 'cebra[datasets,demos]'"
    ]
   },
   {


### PR DESCRIPTION
Adding `pip install --pre cebra` to all notebooks to fetch the latest version, including release candidates.